### PR TITLE
Add Oras and gcloud & Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu:mantic-20230912
-ARG DEBIAN_FRONTEND noninteractive
+FROM ubuntu:lunar
+ARG DEBIAN_FRONTEND=noninteractive
+ARG ORAS_VERSION=1.1.0
 
-RUN apt update -y && apt install -y gnupg openssh-client git jq curl && apt upgrade -y
+RUN apt update -y && apt install -y gnupg openssh-client apt-transport-https ca-certificates git jq curl && apt upgrade -y
 RUN sed -i "s/#   StrictHostKeyChecking ask/StrictHostKeyChecking no/" /etc/ssh/ssh_config && \
     echo "Host *" >> /etc/ssh/ssh_config && \
     export "$(sed -n "/UBUNTU_CODENAME.*/p" /etc/os-release)" && \
@@ -13,5 +14,15 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
     echo "deb [arch=amd64] https://apt.releases.hashicorp.com $UBUNTU_CODENAME main" >> /etc/apt/sources.list
 
 RUN apt update -y && apt install -y ansible packer
+
+RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" && \
+    mkdir -p oras-install/ && \
+    tar -zxf oras_${ORAS_VERSION}_*.tar.gz -C oras-install/ && \
+    mv oras-install/oras /usr/local/bin/ && \
+    rm -rf oras_${ORAS_VERSION}_*.tar.gz oras-install/
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&  \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.asc && \
+    apt update -y && apt install google-cloud-sdk -y
 
 CMD [""]


### PR DESCRIPTION
* Adds ORAS (for OCI image building) and gcloud to image
* Fixes issues with Dockerfile which should resolve the build failures which have occured in recent builds). Changes ubuntu version to `lunar`, as there aren't `mantic` versions of the ansible source (i.e. `"deb http://ppa.launchpad.net/ansible/ansible/ubuntu mantic main"` doens't exist) 