### PR TITLE
Fix hashicorp installations and add new packages to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,6 @@ RUN curl -fsSL https://get.pulumi.com | sh
 
 ENV PATH="$PATH:/root/.pulumi/bin"
 
+RUN apt install python3-pip -y && pip install poetry --break-system-packages
 
 CMD [""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM ubuntu:lunar
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ORAS_VERSION=1.1.0
+ARG TERRAFORM_VERSION=1.9.3
+ARG PACKER_VERSION=1.11.2
 
-RUN apt update -y && apt install -y gnupg openssh-client apt-transport-https ca-certificates git jq curl gnupg software-properties-common && apt upgrade -y
+COPY configure_env.sh /scripts/configure_env.sh
+
+RUN apt update -y && apt install -y gnupg openssh-client apt-transport-https ca-certificates git jq curl gnupg software-properties-common wget zip unzip gettext-base && apt upgrade -y
 
 RUN sed -i "s/#   StrictHostKeyChecking ask/StrictHostKeyChecking no/" /etc/ssh/ssh_config && \
     echo "Host *" >> /etc/ssh/ssh_config && \
@@ -10,14 +14,20 @@ RUN sed -i "s/#   StrictHostKeyChecking ask/StrictHostKeyChecking no/" /etc/ssh/
     echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" >> /etc/apt/sources.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    export "$(sed -n "/UBUNTU_CODENAME.*/p" /etc/os-release)" && \
-    echo "deb [arch=amd64] https://apt.releases.hashicorp.com $UBUNTU_CODENAME main" >> /etc/apt/sources.list
-
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&  \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.asc
 
-RUN apt update -y && apt install -y ansible packer terraform google-cloud-sdk
+RUN apt update -y && apt install ansible google-cloud-sdk -y
+
+RUN apt install google-cloud-sdk-gke-gcloud-auth-plugin python3-pip -y && pip install poetry --break-system-packages
+
+RUN wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"  && \
+    unzip -qn terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin && \
+    rm -rf terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+RUN wget "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"  && \
+    unzip -qn packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/local/bin && \
+    rm -rf packer_${PACKER_VERSION}_linux_amd64.zip
 
 RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" && \
     mkdir -p oras-install/ && \
@@ -28,7 +38,5 @@ RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VER
 RUN curl -fsSL https://get.pulumi.com | sh
 
 ENV PATH="$PATH:/root/.pulumi/bin"
-
-RUN apt install python3-pip -y && pip install poetry --break-system-packages
 
 CMD [""]


### PR DESCRIPTION
### Bug Fixes 
Hashicorps lunar apt repo no longer has a release file causing the following error when attempting to run `apt update`:
```
...
Err:9 https://apt.releases.hashicorp.com lunar Release
  404  Not Found [IP: 18.245.143.73 443]
Get:10 http://packages.cloud.google.com/apt cloud-sdk/main all Packages [1522 kB]
Reading package lists... Done
W: http://ppa.launchpad.net/ansible/ansible/ubuntu/dists/lunar/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
E: The repository 'https://apt.releases.hashicorp.com lunar Release' no longer has a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```
To resolve this have manually downloaded the Terraform and Packer packages, pinning them to version 1.9.3 and 1.11.2 respectively.
### Features 
Adds commonly used packages:
* `wget`
* `zip` and `unzip`
* `gettext-base`
* `python3-pip`
* `poetry`
