### PR TITLE
GitHub Actions for pushing image to docker hub

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -1,0 +1,24 @@
+name: Build and Push latest image
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ github.repository }}:latest

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -1,0 +1,41 @@
+name: Build and Push Release Docker Images
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract version parts
+        id: extract_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR_MINOR_PATCH=$(echo "$VERSION" | awk -F '-' '{print $1}')
+          MAJOR_MINOR=$(echo "$MAJOR_MINOR_PATCH" | awk -F '.' '{print $1"."$2}')
+          MAJOR=$(echo "$MAJOR_MINOR_PATCH" | awk -F '.' '{print $1}')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "MAJOR_MINOR_PATCH=$MAJOR_MINOR_PATCH" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
+          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ github.repository }}:${{ env.MAJOR_MINOR_PATCH }}
+            ${{ github.repository }}:release-${{ env.MAJOR_MINOR }}
+            ${{ github.repository }}:${{ env.MAJOR }}-latest


### PR DESCRIPTION
Adds workflows for pushing Docker image builds to Docker Hub repo.
* On push to main releases `latest` image
* On release tag (format `vX.Y.Z`), creates:
  * `image-builder:vX.Y.Z`
  * `image-builder:release-vX.Y`
  * `image-builder:vX-latest`
Release tag build can also be ran manually, but will only run against a tag, not a branch