### PR TITLE
Downgrade ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:lunar
+FROM ubuntu:jammy
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ORAS_VERSION=1.1.0
 


### PR DESCRIPTION
Changes base image to Ubuntu Jammy which is LTS, rather than lunar which is now unsupported causing errors in pipelines using v1.1